### PR TITLE
Cargo prefers "snake-case" package names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "Fedibook"
+name = "fedibook"
 version = "0.0.0"
 authors = ["Eric Chadbourne <sillystring@protonmail.com>", "Peter Alexander <pipnflinx@gmail.com>", "Elijah Mark Anderson <kd0bpv@gmail.com>"]
 


### PR DESCRIPTION
Just fixing a mistake in Cargo.toml